### PR TITLE
Remove category=cited filter from list of author's publications

### DIFF
--- a/src/10_bibliography.tex
+++ b/src/10_bibliography.tex
@@ -24,7 +24,7 @@
 \section*{List of Author's Publications Covered in this Thesis}
 \nocite{li2002design}
 \newrefcontext[labelprefix=a]
-\printbibliography[keyword=own,heading=empty,category=cited]
+\printbibliography[keyword=own,heading=empty]
 
 
 \section*{References to Scientific Publications}


### PR DESCRIPTION
Line 25 of 10_bibliography.tex  ("\nocite{li2002design}") has no effect when \printbibliography contains category=cited. It is therefore removed.

Note that this gives rise to a further issue: The non-cited references do not have a citation number/name given but still are prefixed by the labelprefix. Both issues probably never appear in a real thesis but are startling during writing.